### PR TITLE
Simplify example

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,15 +44,11 @@ var gulp = require('gulp')
 
 gulp.task('minify', function() {
   return gulp.src('index.js')
-    .pipe(uglify())
+    .pipe(map(function(code, filename) {
+      return uglify.minify(code, { fromString: true })
+    }))
     .pipe(gulp.dest('./dist'))
 })
-
-function uglify() {
-  return map(function(code, filename) {
-    return uglify.minify(code, { fromString: true })
-  })
-}
 ```
 
 ## API ##


### PR DESCRIPTION
I saw that `uglify` was used twice in the readme example, once as a var and again as a function. So I updated to:

``` js
var uglify = require('uglify-js')
var map = require('vinyl-map')
var gulp = require('gulp')

gulp.task('minify', function() {
  return gulp.src('index.js')
    .pipe(minify)
    .pipe(gulp.dest('./dist'))
})

var minify = map(function(code, filename) {
  return uglify.minify(code, { fromString: true })
})
```

But thought it could even be simpler with the proposed changes. Cheers!
