### PR TITLE
check uses callback provided to flush instead of sending 'end' signal

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var bl      = require('bl')
 module.exports = map
 
 function map(fn) {
-  var done = false
+  var done = null
   var pending = 0
   var stream
 
@@ -52,18 +52,13 @@ function map(fn) {
     next()
   }
 
-  function flush() {
-    check(done = true)
+  function flush(cb) {
+    check(done = cb)
   }
 
   function check() {
     if (!pending && done) {
-      process.nextTick(function() {
-        stream.emit('end')
-        process.nextTick(function() {
-          stream.emit('close')
-        })
-      })
+      done();
     }
   }
 }


### PR DESCRIPTION
I had an issue when using vinyl-map with gulp where the stream would end prematurely (i.e. only some of the files where being processed). I think I've found a fix: according to the [node.js stream doc](http://nodejs.org/docs/latest/api/stream.html#stream_transform_flush_callback), the `flush` function should not be sending the `end` signal directly, instead it should call the provided callback after the flush operation is complete (I guess the callback function eventually triggers the `end` signal, but not necessarily right away).

Thanks for the nice work!
