### PR TITLE
bl updated to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "through2": "^0.4.1",
-    "bl": "^0.7.0",
+    "bl": "^0.9.4",
     "new-from": "0.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Version 0.7.0 used in this project right now generated warning:

```
npm WARN peerDependencies The peer dependency stream-browserify@* included from bl will no
npm WARN peerDependencies longer be automatically installed to fulfill the peerDependency 
npm WARN peerDependencies in npm 3+. Your application will need to depend on it explicitly.
```

Better be safe than sorry, so I've bumped this version to latest. Since this project have no tests I only can say that example you have provided works with updated bl :)
